### PR TITLE
Update LeRobot imports for lerobot 0.5.1 module layout

### DIFF
--- a/source/sim_to_real_so101/utils/lerobot_interface.py
+++ b/source/sim_to_real_so101/utils/lerobot_interface.py
@@ -18,8 +18,8 @@ import numpy as np
 import torch
 import uuid
 
-from lerobot.teleoperators.so101_leader import SO101LeaderConfig
-from lerobot.robots.so101_follower import SO101FollowerConfig
+from lerobot.teleoperators.so_leader.config_so_leader import SO101LeaderConfig
+from lerobot.robots.so_follower.config_so_follower import SO101FollowerConfig
 
 from lerobot.cameras.opencv import OpenCVCameraConfig
 from lerobot.configs.policies import PreTrainedConfig
@@ -30,10 +30,10 @@ from lerobot.datasets.pipeline_features import (
     aggregate_pipeline_dataset_features,
     create_initial_features,
 )
-from lerobot.datasets.utils import build_dataset_frame, combine_feature_dicts
+from lerobot.datasets.feature_utils import build_dataset_frame, combine_feature_dicts
 from lerobot.utils.constants import OBS_STR
 from lerobot.utils.control_utils import predict_action
-from lerobot.utils.utils import get_safe_torch_device
+from lerobot.utils.device_utils import get_safe_torch_device
 from lerobot.policies.utils import make_robot_action
 from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
 


### PR DESCRIPTION
## Description

`source/sim_to_real_so101/utils/lerobot_interface.py` imports four symbols from paths
that no longer exist in the current released `lerobot` (**0.5.1**), so the module fails
to import on a fresh install.

## Fix

| Old path | New path |
|----------|----------|
| `lerobot.teleoperators.so101_leader.SO101LeaderConfig` | `lerobot.teleoperators.so_leader.config_so_leader.SO101LeaderConfig` |
| `lerobot.robots.so101_follower.SO101FollowerConfig` | `lerobot.robots.so_follower.config_so_follower.SO101FollowerConfig` |
| `lerobot.datasets.utils.{build_dataset_frame, combine_feature_dicts}` | `lerobot.datasets.feature_utils.{build_dataset_frame, combine_feature_dicts}` |
| `lerobot.utils.utils.get_safe_torch_device` | `lerobot.utils.device_utils.get_safe_torch_device` |

## Validation

All four targets were verified to resolve against an installed `lerobot==0.5.1`:

```
OK  lerobot.teleoperators.so_leader.config_so_leader :: SO101LeaderConfig
OK  lerobot.robots.so_follower.config_so_follower :: SO101FollowerConfig
OK  lerobot.datasets.feature_utils :: build_dataset_frame
OK  lerobot.datasets.feature_utils :: combine_feature_dicts
OK  lerobot.utils.device_utils :: get_safe_torch_device
```

Commit is DCO signed-off.